### PR TITLE
Add support for annotations in a metric

### DIFF
--- a/src/Fhir.Metrics/Model/Metrics.cs
+++ b/src/Fhir.Metrics/Model/Metrics.cs
@@ -15,9 +15,13 @@ namespace Fhir.Metrics
     {
         public List<Prefix> Prefixes = new List<Prefix>();
         public List<Unit> Units = new List<Unit>();
+        public static string Unity = "1";
 
         public Unit FindUnit(string symbol)
         {
+            if (symbol.Equals(Unity))
+                return new Unit("Unity", Unity, "");
+
             return Units.FirstOrDefault(u => u.Symbol == symbol);
         }
 

--- a/src/Fhir.Metrics/Utils/Parser.cs
+++ b/src/Fhir.Metrics/Utils/Parser.cs
@@ -51,17 +51,41 @@ namespace Fhir.Metrics
     public static class Parser
     {
 
-        public static string TokenPattern = @"(((?<m>[\.\/])?(?<m>[^\.\/]+))*)?";
+        public static Regex TokenPattern = new Regex(@"(((?<m>[\.\/])?(?<m>[^\.\/]+))*)?", RegexOptions.Compiled);
+        public static Regex Annontations = new Regex(@"{[^{}]*}", RegexOptions.Compiled);
 
         public static List<string> Tokenize(string expression)
         {
-            bool valid = Regex.IsMatch(expression, TokenPattern);
-            if (!valid)
+            if(Annontations.IsMatch(expression))
+                expression = CanonicalizeAnnotations(expression);
+
+            if (!TokenPattern.IsMatch(expression) || Annontations.IsMatch(expression))
                 throw new ArgumentException("Invalid metric expression");
 
-            Match match = Regex.Match(expression, TokenPattern);
-            return match.Captures("m").ToList();
+            return TokenPattern.Match(expression).Captures("m").ToList();
+        }
 
+        private static string CanonicalizeAnnotations(string expression)
+        {
+            var annotations = new Regex(@"{[^{}]*}", RegexOptions.Compiled);
+            foreach(Match match in annotations.Matches(expression))
+            {
+                if (match.Index == 0) // Expressions contains just an annotation
+                {
+                    expression = Metrics.Unity;
+                }
+                else if (expression[match.Index - 1].Equals('/') || expression[match.Index - 1].Equals('.')) // Annotation is part of a multiplication or division
+                {
+                    expression = expression.Remove(match.Index, match.Length);
+                    expression = expression.Insert(match.Index, Metrics.Unity);
+                }
+                else // e.g. // Annotation is directly combined with another unit
+                {
+                    expression = expression.Remove(match.Index, match.Length);
+                }
+            }
+
+            return expression;
         }
 
         static bool IsOperator(string token)

--- a/src/Fhir.Metrics/Utils/Parser.cs
+++ b/src/Fhir.Metrics/Utils/Parser.cs
@@ -70,16 +70,16 @@ namespace Fhir.Metrics
             var annotations = new Regex(@"{[^{}]*}", RegexOptions.Compiled);
             foreach(Match match in annotations.Matches(expression))
             {
-                if (match.Index == 0) // Expressions contains just an annotation
+                if (match.Index == 0) // Expressions contains just an annotation, e.g. "{rbc}"
                 {
                     expression = Metrics.Unity;
                 }
-                else if (expression[match.Index - 1].Equals('/') || expression[match.Index - 1].Equals('.')) // Annotation is part of a multiplication or division
+                else if (expression[match.Index - 1].Equals('/') || expression[match.Index - 1].Equals('.')) // Annotation is part of a multiplication or division, e.g. "/{count}" or "10*3.{RBC}"
                 {
                     expression = expression.Remove(match.Index, match.Length);
                     expression = expression.Insert(match.Index, Metrics.Unity);
                 }
-                else // e.g. // Annotation is directly combined with another unit
+                else // e.g. // Annotation is directly combined with another unit, e.g. "ml{total}"
                 {
                     expression = expression.Remove(match.Index, match.Length);
                 }

--- a/src/Fhir.Metrics/Utils/Parser.cs
+++ b/src/Fhir.Metrics/Utils/Parser.cs
@@ -52,14 +52,14 @@ namespace Fhir.Metrics
     {
 
         public static Regex TokenPattern = new Regex(@"(((?<m>[\.\/])?(?<m>[^\.\/]+))*)?", RegexOptions.Compiled);
-        public static Regex Annontations = new Regex(@"{[^{}]*}", RegexOptions.Compiled);
+        public static Regex Annotations = new Regex(@"{[^{}]*}", RegexOptions.Compiled);
 
         public static List<string> Tokenize(string expression)
         {
-            if(Annontations.IsMatch(expression))
+            if(Annotations.IsMatch(expression))
                 expression = CanonicalizeAnnotations(expression);
 
-            if (!TokenPattern.IsMatch(expression) || Annontations.IsMatch(expression))
+            if (!TokenPattern.IsMatch(expression) || Annotations.IsMatch(expression))
                 throw new ArgumentException("Invalid metric expression");
 
             return TokenPattern.Match(expression).Captures("m").ToList();

--- a/test/Fhir.Metrics.Tests/Tests/TestMetrics.cs
+++ b/test/Fhir.Metrics.Tests/Tests/TestMetrics.cs
@@ -96,15 +96,19 @@ namespace Fhir.Metrics.Tests
 
             metric = system.Metric("{rbc}");
             Assert.Equal(1, metric.Axes.Count);
+            Assert.Equal("1", metric.Symbols);
 
             metric = system.Metric("mL/min/{1.73_m2}");
             Assert.Equal(3, metric.Axes.Count);
+            Assert.Equal("mL.min-1.1-1", metric.Symbols);
 
             metric = system.Metric("10*3.{RBC}");
             Assert.Equal(2, metric.Axes.Count);
+            Assert.Equal("10*3.1", metric.Symbols);
 
             metric = system.Metric("ml{total}");
             Assert.Equal(1, metric.Axes.Count);
+            Assert.Equal("ml", metric.Symbols);
         }
 
         [Fact]

--- a/test/Fhir.Metrics.Tests/Tests/TestMetrics.cs
+++ b/test/Fhir.Metrics.Tests/Tests/TestMetrics.cs
@@ -87,8 +87,37 @@ namespace Fhir.Metrics.Tests
             // Is now replaced with: (((?[./])?(?[^./]+)))?
             string unit = "ForinterpretationofeGFRseehttp://www.kidney.org.au";
             Assert.Throws<ArgumentException>(() => system.Metric(unit));
-            
-            
+        }
+
+        [Fact]
+        public void MetricWithValidAnnotations()
+        {
+            Metric metric;
+
+            metric = system.Metric("{rbc}");
+            Assert.Equal(1, metric.Axes.Count);
+
+            metric = system.Metric("mL/min/{1.73_m2}");
+            Assert.Equal(3, metric.Axes.Count);
+
+            metric = system.Metric("10*3.{RBC}");
+            Assert.Equal(2, metric.Axes.Count);
+
+            metric = system.Metric("ml{total}");
+            Assert.Equal(1, metric.Axes.Count);
+        }
+
+        [Fact]
+        public void MetricWithInvalidAnnotations()
+        {
+            try
+            {
+                Metric metric = system.Metric("{{1}}");
+            }
+            catch (Exception e)
+            {
+                Assert.IsType<ArgumentException>(e);
+            }
         }
     }
 }


### PR DESCRIPTION
Accept the following metrics as valid:
"/{count}"
"{rbc}"
"ml.{count}"
"mL/min/{1.73_m2}"

