### PR TITLE
Fix conversion path collection

### DIFF
--- a/src/Fhir.Metrics/System/Conversions.cs
+++ b/src/Fhir.Metrics/System/Conversions.cs
@@ -35,11 +35,14 @@ namespace Fhir.Metrics
             do
             {
                 step = Find(m);
-                if (step != null) steps.Add(step);
-                m = step.To;
-                found = predicate(step);
+                if (step != null)
+                {
+                    steps.Add(step);
+                    m = step.To;
+                    found = predicate(step);
+                }
             }
-            while (steps != null && !found);
+            while (step != null && !found);
             if (found)
             {
                 return steps;

--- a/test/Fhir.Metrics.Tests/Tests/TestConversions.cs
+++ b/test/Fhir.Metrics.Tests/Tests/TestConversions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Xunit;
 
 namespace Fhir.Metrics.Tests
@@ -180,6 +181,20 @@ namespace Fhir.Metrics.Tests
             result = system.Canonical(quantity);
             expected = system.Quantity("3.14rad").UnPrefixed();
             Assert.True(result.Approximates(expected));
+        }
+
+        [Fact]
+        public void ConversionPath()
+        {
+            Metric cm = system.Metric("cm");
+            Metric ci = system.Metric("Ci");
+            Metric bq = system.Metric("Bq");
+
+            List<Conversion> can = system.Conversions.Path(ci, x => x.To.Equals(bq));
+            Assert.Single(can);
+
+            List<Conversion> cannot = system.Conversions.Path(cm, x => x.To.Equals(bq));
+            Assert.Null(cannot);
         }
 
         //[Fact]


### PR DESCRIPTION
Hi all,
I fixed a null pointer exception in case a conversion was not found, and the loop condition.
The unit test illustrates that it no longer throws an exception when the conversion is not possible.
Kind regards -- Joost