### PR TITLE
Enable trusted signing

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -40,8 +40,10 @@ stages:
       nuGetSources: --source https://nuget.pkg.github.com/FirelyTeam/index.json
       signingKeyFileName: 'FhirMetrics.snk' 
       filesForSigning: '$(Build.SourcesDirectory)\src\Fhir.Metrics\bin\Release\*\Fhir.Metrics.dll'
-      codeSignerCertificate: $(FirelyCodeSignerCertificate)
-      codeSignerPassword: $(CodeSigningPassword)
+      certificateProfileName: 'FirelyCodeSigning'
+      trustedSigningAccountEndpoint: 'https://weu.codesigning.azure.net/'
+      trustedSigningAccountName: 'FirelyCodeSigning'
+      azureServiceConnectionForSigning: 'AzureTrustedSigningPrincipal'
       pool: 
         vmImage: $(vmImage)
     


### PR DESCRIPTION
This pull request updates the code signing configuration in the Azure Pipelines YAML file. The main change is a shift from using explicit certificate and password variables to a more integrated and secure approach using Azure Trusted Signing.

**Build pipeline improvements:**

* Updated the code signing process in `build/azure-pipelines.yml` to use Azure Trusted Signing by replacing `codeSignerCertificate` and `codeSignerPassword` with `certificateProfileName`, `trustedSigningAccountEndpoint`, `trustedSigningAccountName`, and `azureServiceConnectionForSigning` parameters. This enhances security and aligns with modern Azure DevOps practices.