### PR TITLE
Only sign NuGet packages on v* tag releases

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -40,10 +40,11 @@ stages:
       nuGetSources: --source https://nuget.pkg.github.com/FirelyTeam/index.json
       signingKeyFileName: 'FhirMetrics.snk' 
       filesForSigning: '$(Build.SourcesDirectory)\src\Fhir.Metrics\bin\Release\*\Fhir.Metrics.dll'
-      certificateProfileName: 'FirelyCodeSigning'
-      trustedSigningAccountEndpoint: 'https://weu.codesigning.azure.net/'
-      trustedSigningAccountName: 'FirelyCodeSigning'
-      azureServiceConnectionForSigning: 'AzureTrustedSigningPrincipal'
+      ${{ if startswith(variables['Build.SourceBranch'], 'refs/tags/v') }}:
+        certificateProfileName: 'FirelyCodeSigning'
+        trustedSigningAccountEndpoint: 'https://weu.codesigning.azure.net/'
+        trustedSigningAccountName: 'FirelyCodeSigning'
+        azureServiceConnectionForSigning: 'AzureTrustedSigningPrincipal'
       pool: 
         vmImage: $(vmImage)
     


### PR DESCRIPTION
Signing with Azure Trusted Signing is only needed when publishing to NuGet. This change ensures the signing step is skipped on regular branch builds and only runs when triggered by a `v*` release tag.